### PR TITLE
Only add to state if fetch request has contents.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,11 @@
         for (let index = 0; index < array.length; index++) {
             const file = basePath + array[index];
             const response = await fetch(file);
-            const log = await response.json();
-            log._uri = `/home/m/repos/dashboard/samples/commit_2/${array[index]}`;
-            store.logs.push(log);
+            if (response.ok) {
+                const log = await response.json();
+                log._uri = `/home/steven/osrf/space-ros/dashboard/samples/commit_2/${array[index]}`;
+                store.logs.push(log);
+            }
         }
     }
     await loadLogs(store, baselineFolder + "1/");


### PR DESCRIPTION
This was causing errors loading the dashboard standalone for me because commit_1 of the samples does not have a cpplint.sarif.

I accidentally updated the uri field to _my_ workspace specific path instead of @mayman99's but I plan to fix that in follow-up.